### PR TITLE
Add message metadata

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -169,6 +169,9 @@ This example demonstrates how to add a file attachment to your message.
 ### [Basic send with custom email headers](https://github.com/socketlabs/socketlabs-ruby/blob/master/examples/basic/basic_send_with_custom_headers.rb)
 This example demonstrates how to add custom headers to your email message.
 
+### [Basic send with metadata](https://github.com/socketlabs/socketlabs-ruby/blob/master/examples/basic/basic_send_with_metadata.rb)
+This example demonstrates how to add metadata to your email message.
+
 ### [Basic send with embedded image](https://github.com/socketlabs/socketlabs-ruby/blob/master/examples/basic/basic_send_with_embedded_image.rb)
 This example demonstrates how to embed an image in your message.
 

--- a/examples/basic/basic_send_complex.rb
+++ b/examples/basic/basic_send_complex.rb
@@ -159,6 +159,22 @@ class BasicSendComplex
     message.add_custom_header("testMessageHeader", "I am a message header")
     message.add_custom_header(CustomHeader.new("testMessageHeader2", "I am another message header"))
 
+    # Adding Metadata
+    # --------
+    # Add Metadata using a list
+    metadata = Array.new
+    metadata.push(Metadata.new("x-mycustommetadata", "I am custom metadata"))
+    metadata.push(Metadata.new("x-internalid", "123"))
+
+    message.metadata = metadata
+
+    # Add Metadata directly to the list
+    message.metadata.push(Metadata.new("x-mycustommetadata", "I am custom metadata"))
+
+    # Add Metadata using the add_metadata function
+    message.add_metadata("x-mycustommetadata2", "Custom metadata")
+    message.add_metadata(Metadata.new("x-externalid", "456"))
+
     # Adding Attachments
     attachment1 = Attachment.new(
         name:"bus",

--- a/examples/basic/basic_send_with_metadata.rb
+++ b/examples/basic/basic_send_with_metadata.rb
@@ -1,0 +1,44 @@
+
+require_relative "../../lib/socketlabs-injectionapi.rb"
+require "json"
+
+class BasicSendWithMetadata
+  include SocketLabs::InjectionApi
+  include SocketLabs::InjectionApi::Core
+  include SocketLabs::InjectionApi::Message
+
+  def get_message
+
+    message = BasicMessage.new
+
+    message.subject = "Sending An Email With Custom Headers"
+    message.html_body =  "<html><body>" +
+                    "<h1>Sending An Email With Custom Headers</h1>" +
+                    "<p>This is the Html Body of my message.</p>" +
+                    "</body></html>"
+    message.plain_text_body = "This is the Plain Text Body of my message."
+
+    message.from_email_address = EmailAddress.new("from@example.com")
+    message.add_to_email_address("recipient1@example.com")
+
+    # Adding Metadata
+    # --------
+    # Add Metadata using a list
+    metadata = Array.new
+    metadata.push(Metadata.new("x-mycustommetadata", "I am custom metadata"))
+    metadata.push(Metadata.new("x-internalid", "123"))
+
+    message.metadata = metadata
+
+    # Add Metadata directly to the list
+    message.metadata.push(Metadata.new("x-mycustommetadata", "I am custom metadata"))
+
+    # Add Metadata using the add_metadata function
+    message.add_metadata("x-mycustommetadata2", "Custom metadata")
+    message.add_metadata(Metadata.new("x-externalid", "456"))
+
+
+    message
+  end
+
+end

--- a/examples/bulk/bulk_send_complex.rb
+++ b/examples/bulk/bulk_send_complex.rb
@@ -153,6 +153,22 @@ class BulkSendComplex
     message.add_custom_header("testMessageHeader", "I am a message header")
     message.add_custom_header(CustomHeader.new("testMessageHeader2", "I am another message header"))
 
+    # Adding Metadata
+    # --------
+    # Add Metadata using a list
+    metadata = Array.new
+    metadata.push(Metadata.new("x-mycustommetadata", "I am custom metadata"))
+    metadata.push(Metadata.new("x-internalid", "123"))
+
+    message.metadata = metadata
+
+    # Add Metadata directly to the list
+    message.metadata.push(Metadata.new("x-mycustommetadata", "I am custom metadata"))
+
+    # Add Metadata using the add_metadata function
+    message.add_metadata("x-mycustommetadata2", "Custom metadata")
+    message.add_metadata(Metadata.new("x-externalid", "456"))
+
     # Adding Attachments
     attachment1 = Attachment.new(
         name:"bus",

--- a/lib/socketlabs-injectionapi.rb
+++ b/lib/socketlabs-injectionapi.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 require_relative 'socketlabs/injectionapi/core/send_validator'
 require_relative 'socketlabs/injectionapi/core/string_extension'
 require_relative 'socketlabs/injectionapi/address_result'

--- a/lib/socketlabs/injectionapi/core/injection_request_factory.rb
+++ b/lib/socketlabs/injectionapi/core/injection_request_factory.rb
@@ -4,10 +4,12 @@ require_relative '../message/email_address.rb'
 require_relative '../message/bulk_message.rb'
 require_relative '../message/bulk_recipient.rb'
 require_relative '../message/custom_header.rb'
+require_relative '../message/metadata.rb'
 
 require_relative 'serialization/address_json.rb'
 require_relative 'serialization/attachment_json.rb'
 require_relative 'serialization/custom_header_json.rb'
+require_relative 'serialization/metadata_json.rb'
 require_relative 'serialization/message_json.rb'
 require_relative 'serialization/merge_data_json.rb'
 
@@ -68,6 +70,7 @@ module SocketLabs
           message_json.charset = message.charset
           message_json.from_email_address = email_address_to_address_json(message.from_email_address)
           message_json.custom_headers = populate_custom_headers(message.custom_headers)
+          message_json.metadata = populate_metadata(message.metadata)
           message_json.attachments = populate_attachments(message.attachments)
 
           unless message.api_template.nil?
@@ -80,7 +83,7 @@ module SocketLabs
 
         end
 
-        # Converts a list of Attachment objects to a List of AttachmentJson objects.
+        # Converts a list of CustomHeader objects to a List of CustomHeaderJson objects.
         # @param [Array] custom_headers: list of CustomHeader to convert
         # @return [Array] the converted list of CustomHeaderJson
         def populate_custom_headers(custom_headers)
@@ -100,6 +103,29 @@ module SocketLabs
           end
 
           headers_json
+
+        end
+
+        # Converts a list of Metadata objects to a List of MetadataJson objects.
+        # @param [Array] metadata: list of Metadata to convert
+        # @return [Array] the converted list of MetadataJson
+        def populate_metadata(metadata)
+
+          if metadata.nil? || metadata.empty?
+            nil
+          end
+
+          metadata_json = Array.new
+
+          metadata.each do |header|
+            if header.instance_of? Metadata
+              metadata_json.push(MetadataJson.new(header.name, header.value))
+            elsif header.instance_of? Hash
+              metadata_json.push(MetadataJson.new(header[:name], header[:value]))
+            end
+          end
+
+          metadata_json
 
         end
 

--- a/lib/socketlabs/injectionapi/core/send_validator.rb
+++ b/lib/socketlabs/injectionapi/core/send_validator.rb
@@ -4,6 +4,7 @@ require_relative '../message/email_address.rb'
 require_relative '../message/bulk_message.rb'
 require_relative '../message/bulk_recipient.rb'
 require_relative '../message/custom_header.rb'
+require_relative '../message/metadata.rb'
 
 module SocketLabs
   module InjectionApi
@@ -81,6 +82,9 @@ module SocketLabs
           end
           unless has_valid_custom_headers(message.custom_headers)
             SendResult.enum["MessageValidationInvalidCustomHeaders"]
+          end
+          unless has_valid_metadata(message.metadata)
+            SendResult.enum["MessageValidationInvalidMetadata"]
           end
 
           SendResult.enum["Success"]
@@ -340,6 +344,25 @@ module SocketLabs
           unless custom_headers.nil? || custom_headers.empty?
             custom_headers.each do |item|
               if item.instance_of? CustomHeader
+                unless item.is_valid
+                  false
+                end
+              end
+            end
+          end
+
+          true
+
+        end
+
+        # Check if the list of metadata is valid
+        # @param [Array] metadata
+        # @return [Array]
+        def has_valid_metadata(metadata)
+
+          unless metadata.nil? || metadata.empty?
+            metadata.each do |item|
+              if item.instance_of? Metadata
                 unless item.is_valid
                   false
                 end

--- a/lib/socketlabs/injectionapi/core/send_validator.rb
+++ b/lib/socketlabs/injectionapi/core/send_validator.rb
@@ -45,7 +45,7 @@ module SocketLabs
             SendResponse.new(result=SendResult.enum["AuthenticationValidationFailed"])
           end
 
-          if server_id.nil? || server_id.empty?
+          if server_id.nil? || (!server_id.is_a?(Integer) && server_id.empty?)
             SendResponse.new(result=SendResult.enum["AuthenticationValidationFailed"])
           end
 

--- a/lib/socketlabs/injectionapi/core/serialization/message_json.rb
+++ b/lib/socketlabs/injectionapi/core/serialization/message_json.rb
@@ -44,6 +44,7 @@ module SocketLabs
             @merge_data = MergeDataJson.new
             @attachments = Array.new
             @custom_headers = Array.new
+            @metadata = Array.new
             @to_email_address = Array.new
             @cc_email_address = Array.new
             @bcc_email_address = Array.new
@@ -82,6 +83,7 @@ module SocketLabs
           def custom_headers
             @custom_headers
           end
+
           # Set the list of CustomHeaderJson.
           # @param [Array] value
           def custom_headers=(value)
@@ -100,6 +102,34 @@ module SocketLabs
           def add_custom_header(value)
             if value.instance_of? CustomHeaderJson
               @custom_headers.push(value)
+            end
+          end
+
+          #metadata
+          # Get the list of MetadataJson.
+          # @return [Array]
+          def metadata
+            @metadata
+          end
+
+          # Set the list of MetadataJson.
+          # @param [Array] value
+          def metadata=(value)
+            @metadata = Array.new
+            unless value.nil? || value.empty?
+              value.each do |v1|
+                if v1.instance_of? MetadataJson
+                  @metadata.push(v1)
+                end
+              end
+            end
+          end
+
+          # Add a MetadataJson to the metadata list
+          # @param [MetadataJson] value
+          def add_metadata(value)
+            if value.instance_of? MetadataJson
+              @metadata.push(value)
             end
           end
 
@@ -231,6 +261,14 @@ module SocketLabs
                 e.push(value.to_hash)
               end
               json[:customHeaders] = e
+            end
+
+            unless @metadata.nil? || @metadata.length == 0
+              e = Array.new
+              @metadata.each do |value|
+                e.push(value.to_hash)
+              end
+              json[:metadata] = e
             end
 
             unless @attachments.nil? || @attachments.length == 0

--- a/lib/socketlabs/injectionapi/core/serialization/metadata_json.rb
+++ b/lib/socketlabs/injectionapi/core/serialization/metadata_json.rb
@@ -1,0 +1,40 @@
+module SocketLabs
+  module InjectionApi
+    module Core
+      module Serialization
+
+        # Represents metadata as a name and value pair.
+        # To be serialized into JSON string before sending to the Injection Api.
+        class MetadataJson
+
+          # name of the metadata.
+          attr_accessor :name
+          # value of the metadata.
+          attr_accessor :value
+
+          # Initializes a new instance of the MetadataJson class
+          # @param [String] name
+          # @param [String] value
+          def initialize(
+            name = nil,
+            value = nil
+          )
+            @name = name
+            @value = value
+          end
+
+          # build json hash for MetadataJson
+          # @return [hash]
+          def to_hash
+            {
+              :name => @name,
+              :value => @value
+            }
+          end
+
+        end
+
+      end
+    end
+  end
+end

--- a/lib/socketlabs/injectionapi/message/basic_message.rb
+++ b/lib/socketlabs/injectionapi/message/basic_message.rb
@@ -87,6 +87,7 @@ module SocketLabs
               replyTo: @reply_to_email_address,
               attachments: @attachments,
               customHeaders: @custom_headers,
+              metadata: @metadata,
               to: @to_email_address,
               cc: @cc_email_address,
               bcc: @bcc_email_address

--- a/lib/socketlabs/injectionapi/message/bulk_message.rb
+++ b/lib/socketlabs/injectionapi/message/bulk_message.rb
@@ -55,6 +55,7 @@ module SocketLabs
             replyTo: @reply_to_email_address,
             attachments: @attachments,
             customHeaders: @custom_headers,
+            metadata: @metadata,
             to: @to_recipient,
             global_merge_data: @global_merge_data
           }

--- a/lib/socketlabs/injectionapi/message/message_base.rb
+++ b/lib/socketlabs/injectionapi/message/message_base.rb
@@ -77,6 +77,7 @@ module SocketLabs
 
           @attachments = Array.new
           @custom_headers = Array.new
+          @metadata = Array.new
 
         end
 
@@ -140,6 +141,7 @@ module SocketLabs
         def custom_headers
           @custom_headers
         end
+
         # Set the list of custom message headers added to the message.
         def custom_headers=(value)
           @custom_headers = Array.new
@@ -153,6 +155,7 @@ module SocketLabs
             end
           end
         end
+
         # Add a CustomHeader to the message.
         # @param [String/CustomHeader] name
         # @param [String] value
@@ -168,7 +171,39 @@ module SocketLabs
 
         end
 
+        # Get the list of metadata added to the message.
+        def metadata
+          @metadata
+        end
 
+        # Set the list of metadata added to the message.
+        def metadata=(value)
+          @metadata = Array.new
+          unless value.nil? || value.empty?
+            value.each do |v1|
+              if v1.instance_of? Metadata
+                @metadata.push(v1)
+              else
+                raise StandardError("Invalid type for metadata, type of 'Metadata' was expected")
+              end
+            end
+          end
+        end
+
+        # Add a Metadata to the message.
+        # @param [String/Metadata] name
+        # @param [String] value
+        def add_metadata(name, value = nil)
+
+          if name.kind_of? Metadata
+            @metadata.push(name)
+
+          elsif name.kind_of? String
+            @metadata.push(Metadata.new(name, value))
+
+          end
+
+        end
 
       end
     end

--- a/lib/socketlabs/injectionapi/message/metadata.rb
+++ b/lib/socketlabs/injectionapi/message/metadata.rb
@@ -1,0 +1,52 @@
+require_relative '../core/string_extension.rb'
+
+module SocketLabs
+  module InjectionApi
+    module Message
+
+      # Represents metadata as a name-value pair.
+      # Example:
+      #
+      #   metadata1 = Metadata.new
+      #   metadata1.name = "name1"
+      #   metadata1.value = "value1"
+      #
+      #   metadata2 = Metadata.new("name2", "value2")
+
+      class Metadata
+
+        # the name of the metadata item
+        attr_accessor :name
+        # the value of the metadata item
+        attr_accessor :value
+
+        # Initializes a new instance of the Metadata class
+        # @param [String] name
+        # @param [String] value
+        def initialize(
+            name = nil,
+            value = nil
+        )
+          @name = name
+          @value = value
+        end
+
+        # Determines if the Metadata is valid.
+        # @return [Boolean]
+        def is_valid
+          valid_name = !(@name.nil? || @name.empty?)
+          valid_value = !(@value.nil? || @value.empty?)
+
+          valid_name && valid_value
+        end
+
+        # Represents the Metadata name-value pair as a String
+        # @return [String]
+        def to_s
+            "#{@name}, #{@value}"
+        end
+
+      end
+    end
+  end
+end

--- a/lib/socketlabs/injectionapi/send_result.rb
+++ b/lib/socketlabs/injectionapi/send_result.rb
@@ -308,6 +308,14 @@ module SocketLabs
             :value =>37,
             :message =>"SDK Validation Error: Expected messageType of basic or bulk"
 
+          },
+
+        # SDK Validation Error: Message contains invalid metadata
+        "MessageValidationInvalidMetadata" =>
+          {
+            :name =>"MessageValidationInvalidMetadata",
+            :value =>38,
+            :message =>"SDK Validation Error: Message contains invalid metadata"
           }
 
           }


### PR DESCRIPTION
Thanks for merging in my previous PR, @david-schrenker!

Metadata is not currently supported in the lib. I added helpers to support adding metadata to both basic and complex messages and added an example.

I followed the examples in CustomHeader and mimicked use wherever used. 

Attachments do not include metadata since I didn't see any support for it, though happy to add that if y'all would like!

This was tested by manually constructing a send message and sending a few emails to myself with and without metadata. 

Two bugs I ran into:
* JSON is typically included somewhere in an app that would consume this lib, so helpers like `to_json` are usually available for use. However when using the library standalone, it is not included causing exceptions when attempting to convert hashes to json. I added `require 'json'` to ensure it is available. 
* Validation fails when passing an integer server_id to `SocketLabsClient.new(10000, "YOUR-API-KEY")` since `.empty?` is not available on integer objects. I added a check to non-integer values in the validator to enable this. Note: Passing a string containing the server_id does work like in `SocketLabsClient.new("10000", "YOUR-API-KEY")` but the example given in the README uses an integer, so this is now supported.